### PR TITLE
(MR-108) Update signin and signup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2648,6 +2648,12 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.5.tgz",
       "integrity": "sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ=="
     },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
     "@types/react": {
       "version": "17.0.37",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
-    "@types/qs": "6.9.7",
     "@types/react-router-dom": "^5.3.3",
     "axios": "0.24.0",
     "markdown-to-jsx": "^7.1.5",
@@ -60,5 +59,8 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://localhost:8080"
+  "proxy": "http://localhost:8080",
+  "devDependencies": {
+    "@types/qs": "^6.9.7"
+  }
 }

--- a/src/pages/User/SignIn.tsx
+++ b/src/pages/User/SignIn.tsx
@@ -22,7 +22,7 @@ export default function SignInSide() {
 
     try {
       const res = await userService.signIn(
-        user_data.get("email"),
+        user_data.get("accountId"),
         user_data.get("password")
       );
 
@@ -31,7 +31,7 @@ export default function SignInSide() {
       window.location.href = "/";
 
       localStorage.setItem("accessToken", res.data.accessToken);
-      localStorage.setItem("userId", res.data.userInfo.id);
+      localStorage.setItem("accountId", res.data.userInfo.accountId);
 
       return res;
     } catch (error) {
@@ -93,10 +93,10 @@ export default function SignInSide() {
                   margin="normal"
                   required
                   fullWidth
-                  id="email"
-                  label="Email Address"
-                  name="email"
-                  autoComplete="email"
+                  id="accountId"
+                  label="Account ID"
+                  name="accountId"
+                  autoComplete="text"
                   autoFocus
                 />
                 <TextField
@@ -123,20 +123,16 @@ export default function SignInSide() {
                   로그인
                 </Button>
               </Box>
-              <Box
-                  component="form"
-                  noValidate
-                  sx={{ mt: 1 }}
-              >
+              <Box component="form" noValidate sx={{ mt: 1 }}>
                 <Button
                   id="sns_login_button"
                   fullWidth
                   variant="contained"
                   sx={{ mt: 3, mb: 1 }}
-                  href = { GOOGLE_OAUTH_URI }
-              >
-                구글아이디로 로그인
-              </Button>
+                  href={GOOGLE_OAUTH_URI}
+                >
+                  구글아이디로 로그인
+                </Button>
               </Box>
             </Box>
           </Grid>

--- a/src/pages/User/SignUp.tsx
+++ b/src/pages/User/SignUp.tsx
@@ -21,7 +21,7 @@ export default function SignUP() {
 
     try {
       const res = await userService.signUp(
-        user_data.get("ID"),
+        user_data.get("accountId"),
         user_data.get("email"),
         user_data.get("password")
       );
@@ -68,8 +68,8 @@ export default function SignUP() {
                       autoFocus
                       fullWidth
                       type="string"
-                      id="ID"
-                      name="ID"
+                      id="accountId"
+                      name="accountId"
                       label="사용자 ID"
                     />
                   </Grid>

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,33 +1,37 @@
-import {signInUserItem, signUpUserItem} from "../types/userItem";
+import { signInUserItem, signUpUserItem } from "../types/userItem";
 import axios from "axios";
 
-class UserService{
-    //Signin.tsx
-    signIn(email : string | null, password: string | null){
-        return axios.post<signInUserItem>(
-        "http://localhost:8080/user/login",
-        { 'email': email, 'password': password },
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-          },
-        }
-      );
-    }
-    //SignUp.tsx
-    signUp(id : string | null, email: string | null, password: string | null){
-        return axios.post<signUpUserItem>(
-        "http://localhost:8080/user/signup",
-        { 'id': id, 'email': email, 'password': password },
-        {
-          headers: {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-          },
-        }
-      );
-    }
+class UserService {
+  //Signin.tsx
+  signIn(email: string | null, password: string | null) {
+    return axios.post<signInUserItem>(
+      "http://localhost:8080/user/login",
+      { email: email, password: password },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+      }
+    );
+  }
+  //SignUp.tsx
+  signUp(
+    accountId: string | null,
+    email: string | null,
+    password: string | null
+  ) {
+    return axios.post<signUpUserItem>(
+      "http://localhost:8080/user/signup",
+      { accountId: accountId, email: email, password: password },
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+      }
+    );
+  }
 }
 
 export default new UserService();

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -3,10 +3,10 @@ import axios from "axios";
 
 class UserService {
   //Signin.tsx
-  signIn(email: string | null, password: string | null) {
+  signIn(accountId: string | null, password: string | null) {
     return axios.post<signInUserItem>(
       "http://localhost:8080/user/login",
-      { email: email, password: password },
+      { accountId: accountId, password: password },
       {
         headers: {
           "Content-Type": "application/json",

--- a/src/types/userItem.ts
+++ b/src/types/userItem.ts
@@ -1,13 +1,13 @@
 export interface signInUserItem {
-    grantType: string;
-    accessToken: string;
-    refreshToken: string;
-    accessTokenExpiresIn: number;
-    userInfo: {
-      id: string;
-    };
+  grantType: string;
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresIn: number;
+  userInfo: {
+    accountId: string;
+  };
 }
 
 export interface signUpUserItem {
-    id: string;
+  accountId: string;
 }


### PR DESCRIPTION
업데이트된 내용 (email 대신에 accountId로 로그인, 회원가입시 id받기 등) signin, signup에서의 api 요청 파라미터 이름을 바꾸었습니다!
[테스트 방식]
 1)안전빵으로 npm install한 뒤에 npm start.  
   
 2)회원가입 페이지에서 회원가입.  
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/44168693/202657074-bdcfcd8b-b262-40bb-b542-c04691bc5a40.png">
-> Alert를 닫으면 로그인 페이지로.      
                             
 3)로그인 페이지에서 회원가입했던 계정을 입력.
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/44168693/202658496-ad9abd92-0246-46ec-9456-5a4e3cfde922.png">
           
-> 이메일이 아닌 아이디!입력해야함.  
